### PR TITLE
TLUNIZIN-148 adding syllabus api and refactoring

### DIFF
--- a/src/main/java/edu/umich/tl/ApiCallHandler.java
+++ b/src/main/java/edu/umich/tl/ApiCallHandler.java
@@ -42,7 +42,7 @@ public class ApiCallHandler {
 	public enum RequestTypeEnum{
 		TERM, UNPUBLISHED_COURSE_LIST, UNPUBLISHED_COURSE_LIST_PAGINATION_URL, 
 		ASSIGNMENT,ANNOUNCEMENT,CONFERENCE,DISCUSSION_TOPICS,FILES,GRADE_CHANGES,GROUPS,MODULES,
-		PAGES,QUIZZES,EXTERNAL_TOOLS,COURSE_AUDIT_LOGS,COURSE_AUDIT_LOGS_PAGINALTION_URL,COURSE_DELETE;
+		PAGES,QUIZZES,EXTERNAL_TOOLS,COURSE_AUDIT_LOGS,COURSE_DELETE,SYLLABUS;
 	}
 
 	public HttpResponse getApiResponse(RequestTypeEnum requestType, String canvasTermIdForSisTermId, String url,String courseId) {
@@ -95,15 +95,14 @@ public class ApiCallHandler {
 			urlSuffix=API_VERSION+COURSES+courseId+"/external_tools";
 			break;
 		case COURSE_AUDIT_LOGS:
-			urlSuffix=API_VERSION+"/audit/course"+COURSES+courseId+"?"+PER_PAGE;
-			break;
-		case COURSE_AUDIT_LOGS_PAGINALTION_URL:
-			urlSuffix=url;
-			shouldAddPrefix=false;
+			urlSuffix=API_VERSION+"/audit/course"+COURSES+courseId;
 			break;
 		case COURSE_DELETE:
 			urlSuffix=API_VERSION+COURSES+courseId+"?event=delete";
 			request=DELETE;
+			break;
+		case SYLLABUS:	
+			urlSuffix=API_VERSION+COURSES+courseId+"?include=syllabus_body";
 			break;
 		default:
 			M_log.warn("Unknown RequestType \""+requestType+"\" encounted");

--- a/src/main/java/edu/umich/tl/ApiCallHandler.java
+++ b/src/main/java/edu/umich/tl/ApiCallHandler.java
@@ -2,6 +2,7 @@ package edu.umich.tl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -40,11 +41,18 @@ public class ApiCallHandler {
 	}
 	
 	public enum RequestTypeEnum{
-		TERM, UNPUBLISHED_COURSE_LIST, UNPUBLISHED_COURSE_LIST_PAGINATION_URL, 
-		ASSIGNMENT,ANNOUNCEMENT,CONFERENCE,DISCUSSION_TOPICS,FILES,GRADE_CHANGES,GROUPS,MODULES,
-		PAGES,QUIZZES,EXTERNAL_TOOLS,COURSE_AUDIT_LOGS,COURSE_DELETE,SYLLABUS;
+		TERM, UNPUBLISHED_COURSE_LIST, UNPUBLISHED_COURSE_LIST_PAGINATION_URL,COURSE_AUDIT_LOGS,COURSE_DELETE,
+		FILES, ASSIGNMENT, ANNOUNCEMENT,  QUIZZES, MODULES, GRADE_CHANGES, CONFERENCE, DISCUSSION_TOPICS, SYLLABUS, GROUPS, PAGES, EXTERNAL_TOOLS;
+		/*
+		 * EnumSet is an ordered list(Iteration will traverses the elements in the order in which the enum constants are declared). 
+		 * The tools like file, assignment etc are more likely to have content in courses than rest of tools. 
+		 * So when checking for the content case we can break out of loop quickly and save calling rest of the api's.
+		 * hence the 'contentReqType' order need to be preserved.
+		 * The order of EnumSet(contentReqType) and the enum(RequestTypeEnum) should be same other wise the order of the enum get picked. 
+		 */
+		public static EnumSet<RequestTypeEnum> contentReqType=EnumSet.of(FILES, ASSIGNMENT, ANNOUNCEMENT, QUIZZES, MODULES, 
+				GRADE_CHANGES, CONFERENCE, DISCUSSION_TOPICS, SYLLABUS, GROUPS, PAGES, EXTERNAL_TOOLS); 
 	}
-
 	public HttpResponse getApiResponse(RequestTypeEnum requestType, String canvasTermIdForSisTermId, String url,String courseId) {
 		String urlSuffix = null;
 		boolean shouldAddPrefix=true;

--- a/src/main/java/edu/umich/tl/CourseDelete.java
+++ b/src/main/java/edu/umich/tl/CourseDelete.java
@@ -2,6 +2,7 @@ package edu.umich.tl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -351,94 +352,18 @@ public class CourseDelete {
 
 	private static boolean isThereContentInCourse(Course course, ApiCallHandler apiHandler) {
 		M_log.debug("isTheirContentInCourse: "+course.getCourseId());
-		if(areThereFiles(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Files has content for Course: "+course.getCourseId());
-			return true;
-		}
-		if(areThereAssignments(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Assignments has content for Course: "+course.getCourseId());
-			return true;
-		}
-		if(areThereAnnouncements(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Announcements has content for Course: "+course.getCourseId());
-			return true;
-		}
-		if(areThereQuizzes(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Quizzes has content for Course: "+course.getCourseId());
-			return true;
-		} 
-		if(areThereModules(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Modules has content for Course: "+course.getCourseId());
-			return true;
-		} 
-		if(areThereGradeChanges(course.getCourseId(),apiHandler)) {
-			M_log.info("*** GradeChanges has content for Course: "+course.getCourseId());
-			return true;
-		} 
-		if(areThereConferences(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Conferences has content for Course: "+course.getCourseId());
-			return true;
-		} 
-		if(areThereDiscussionTopics(course.getCourseId(),apiHandler)) {
-			M_log.info("*** DiscussionTopics has content for Course: "+course.getCourseId());
-			return true;
-		} 
-		if(areThereSyllabus(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Syllabus has content for Course: "+course.getCourseId());
-			return true;
-		} 
-		if(areThereGroups(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Groups has content for Course: "+course.getCourseId());
-			return true;
-		} 
-		if(areTherePages(course.getCourseId(),apiHandler)) {
-			M_log.info("*** Pages has content for Course: "+course.getCourseId());
-			return true;
-		}
-		if(areThereExternalToolsAdded(course.getCourseId(),apiHandler)) {
-			M_log.info("*** ExternalTools has content for Course: "+course.getCourseId());
-			return true;
+		boolean response=false;
+		EnumSet<RequestTypeEnum> contentReqType = RequestTypeEnum.contentReqType;
+		for (RequestTypeEnum requestType : contentReqType) {
+			if(apiResponseTemplate(course.getCourseId(),apiHandler,requestType)){
+				M_log.info(requestType.name()+ " has content for Course: "+course.getCourseId());
+				return true;
+			}
 		}
 		M_log.info("*** NO Content in Course: "+course.getCourseId());
-		return false;
+		return response;
 	}
-
-	private static boolean areThereAssignments(String courseId,ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.ASSIGNMENT);
-	}
-	private static boolean areThereQuizzes(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.QUIZZES);
-	}
-	private static boolean areThereAnnouncements(String courseId,ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.ANNOUNCEMENT);
-	}
-	private static boolean areThereDiscussionTopics(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.DISCUSSION_TOPICS);
-	}
-	private static boolean areThereFiles(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.FILES);
-	}
-	private static boolean areThereGroups(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.GROUPS);
-	}
-	private static boolean areThereModules(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.MODULES);
-	}
-	private static boolean areTherePages(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.PAGES);
-	}
-	private static boolean areThereExternalToolsAdded(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.EXTERNAL_TOOLS);
-	}
-	private static boolean areThereGradeChanges(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.GRADE_CHANGES);
-	}
-	private static boolean areThereConferences(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler,RequestTypeEnum.CONFERENCE);
-	}
-	private static boolean areThereSyllabus(String courseId, ApiCallHandler apiHandler) {
-		return apiResponseTemplate(courseId, apiHandler, RequestTypeEnum.SYLLABUS);
-	}
+	
     /* This checks for activity in a course, we are looking for the "manually published" events in the past. Please note that the course we are checking 
      * is an unpublished course currently, we don't want to delete "manually published" course in the past as this indicates that the course is still in interest to an instructor.  
      */


### PR DESCRIPTION
1) Adding the Syllabus api to already existing logic for un used courses deletion for terms. The syllabus api response is different from the rest of the api that is present so need to refactor the code to reduce the repetition.

2) Also fixed the api call with Course audit log, removed the pagination as i realized canvas is sending the api response as a SET
 `{
    "links": {
        "events.course": "https://umich.beta.instructure.com/api/v1/courses/{events.course}",
        "events.user": null,
        "events.sis_batch": null
    },
    "events": [],
    "linked": {
        "page_views": [],
        "courses": [],
        "users": []
    }
}
`
 instead of [ ].
